### PR TITLE
enforce retries on s3

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -19,10 +19,12 @@ type Client struct {
 
 func New(bucket string) (*Client, error) {
 	s3Config := &aws.Config{
-		Credentials:      credentials.NewStaticCredentials(os.Getenv("S3_KEY_ID"), os.Getenv("S3_APPLICATION_KEY"), ""),
-		Endpoint:         aws.String(os.Getenv("S3_ENDPOINT")),
-		Region:           aws.String(os.Getenv("S3_REGION")),
-		S3ForcePathStyle: aws.Bool(true),
+		Credentials:             credentials.NewStaticCredentials(os.Getenv("S3_KEY_ID"), os.Getenv("S3_APPLICATION_KEY"), ""),
+		Endpoint:                aws.String(os.Getenv("S3_ENDPOINT")),
+		Region:                  aws.String(os.Getenv("S3_REGION")),
+		S3ForcePathStyle:        aws.Bool(true),
+		MaxRetries:              aws.Int(10),
+		EnforceShouldRetryCheck: aws.Bool(true),
 	}
 	newSession, err := session.NewSession(s3Config)
 


### PR DESCRIPTION
on our development instance https://dev.pomu.app we'd sometimes hit 500/503 from Backblaze with the message `no tomes available`. hopefully this fixes it :)

ref: https://www.backblaze.com/blog/b2-503-500-server-error/