### PR TITLE
add option to automatically save streams (holodex integration)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,9 @@ SENTRY_ENVIRONMENT=production
 SENTRY_RELEASE=v0.0.1
 SENTRY_SAMPLE_RATE=0.2
 SENTRY_DEBUG=false
+
+# Automatically fetch streams from Holodex regularly and add them to queue
+HOLODEX_ENABLE=false
+HOLODEX_API_KEY=
+HOLODEX_ORGS="Hololive,Nijisanji,VShojo,VOMS,PRISM"
+HOLODEX_TOPIC=singing

--- a/holodex.go
+++ b/holodex.go
@@ -21,6 +21,7 @@ func QueueUpcomingStreams(app *Application) {
 
 		if err != nil {
 			log.Printf("failed to query upcoming streams for org %s\n", org)
+			continue
 		}
 
 		log.Printf("found %d streams for %s matching holodex criteria\n", len(streams), org)

--- a/holodex.go
+++ b/holodex.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/getsentry/sentry-go"
+	"github.com/lib/pq"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+func QueueUpcomingStreams(app *Application) {
+	orgs := strings.Split(os.Getenv("HOLODEX_ORGS"), ",")
+
+	for _, org := range orgs {
+		streams, err := queryUpcomingStreams(org)
+
+		if err != nil {
+			log.Printf("failed to query upcoming streams for org %s\n", org)
+		}
+
+		log.Printf("found %d streams for %s matching holodex criteria\n", len(streams), org)
+
+		for _, stream := range streams {
+			if len(stream.Id) <= 0 {
+				log.Printf("%s has no reservation up, skipping\n", stream.Id)
+				continue
+			}
+
+			tx, err := app.db.Begin()
+
+			if err != nil {
+				sentry.CaptureException(err)
+				log.Printf("failed to start transaction: %s\n", err)
+				continue
+			}
+
+			var video Video
+			err = tx.QueryRow("select * from videos where id = $1 limit 1", stream.Id).Scan(
+				&video.Id,
+				pq.Array(&video.Submitters),
+				&video.Start,
+				&video.Finished,
+				&video.Title,
+				&video.ChannelName,
+				&video.ChannelId,
+				&video.Thumbnail,
+				&video.FileSize,
+				&video.Length)
+
+			// Video already exists in db, skip it
+			if err == nil {
+				log.Printf("skipping %s as it already is scheduled to be saved", stream.Id)
+				continue
+			}
+
+			videoMetadata, err := GetVideoMetadata(stream.Id)
+			if err != nil {
+				sentry.CaptureException(err)
+				log.Printf("failed to get video meta data for %s: %s", stream.Id, err)
+				continue
+			}
+
+			startTime, err := GetVideoStartTime(videoMetadata)
+
+			if err != nil {
+				sentry.CaptureException(err)
+				log.Printf("failed to get video start time for %s: %s\n", stream.Id, err)
+				continue
+			}
+
+			thumbnailUrl, err := SaveThumbnail(stream.Id, FindSuitableThumbnail(videoMetadata.Snippet.Thumbnails))
+
+			if err != nil {
+				sentry.CaptureException(err)
+				log.Printf("failed to save thumbnail for %s: %s\n", stream.Id, err)
+				continue
+			}
+
+			statement, err := tx.Prepare("insert into videos (id, submitters, start, title, channel_name, channel_id, thumbnail) values ($1, $2, $3, $4, $5, $6, $7) returning *")
+
+			if err != nil {
+				sentry.CaptureException(err)
+				log.Printf("failed to create video for %s\n", stream.Id)
+				continue
+			}
+
+			row := statement.QueryRow(stream.Id, pq.Array([]string{"pomu.app"}), startTime, videoMetadata.Snippet.Title, videoMetadata.Snippet.ChannelTitle, videoMetadata.Snippet.ChannelId, thumbnailUrl)
+
+			if err := row.Err(); err != nil {
+				sentry.CaptureException(err)
+				log.Printf("failed to create video for %s\n", stream.Id)
+				continue
+			}
+
+			if err = row.Scan(&video.Id,
+				pq.Array(&video.Submitters),
+				&video.Start,
+				&video.Finished,
+				&video.Title,
+				&video.ChannelName,
+				&video.ChannelId,
+				&video.Thumbnail,
+				&video.FileSize,
+				&video.Length); err != nil {
+				log.Printf("failed to get video for %s\n", stream.Id)
+				sentry.CaptureException(err)
+
+				continue
+			}
+
+			if err := tx.Commit(); err != nil {
+				sentry.CaptureException(err)
+				log.Printf("failed to commit transaction: %s\n", err)
+				continue
+			}
+
+			err = app.scheduleVideo(videoMetadata, video.Id, VideoRequest{
+				VideoUrl: fmt.Sprintf("https://youtu.be/%s", video.Id),
+				// Use 0 to auto-pick best quality
+				Quality: 0,
+			})
+
+			if err != nil {
+				log.Printf("failed to automatically schedule video %s: %s\n", video.Id, err)
+				continue
+			}
+
+			log.Printf("Automatically scheduled %s (title: \"%s\") for %s\n", video.Id, video.Title, startTime.Format(time.RFC1123))
+		}
+	}
+}
+
+type UpcomingStreamChannel struct {
+	Id           string `json:"id"`
+	Name         string `json:"name"`
+	Organization string `json:"org"`
+	EnglishName  string `json:"english_name"`
+}
+
+type UpcomingStream struct {
+	Id               string                `json:"id"`
+	Title            string                `json:"title"`
+	StartedScheduled string                `json:"start_scheduled"`
+	Channel          UpcomingStreamChannel `json:"channel"`
+}
+
+func queryUpcomingStreams(organization string) ([]UpcomingStream, error) {
+	request, err := http.NewRequest("GET", "https://holodex.net/api/v2/live", nil)
+
+	if err != nil {
+		fmt.Printf("Failed to start new request to holodex: %s", err)
+		return nil, err
+	}
+
+	request.Header.Set("X-APIKEY", os.Getenv("HOLODEX_API_KEY"))
+	request.Header.Set("User-Agent", "pomu.app")
+
+	query := request.URL.Query()
+
+	query.Set("include", "live_info")
+	query.Set("limit", "50")
+	query.Set("topic", os.Getenv("HOLODEX_TOPIC"))
+	query.Set("type", "stream")
+	query.Set("status", "upcoming")
+	query.Set("max_upcoming_hours", "24") // We query every hour anyways
+	query.Set("org", organization)
+
+	request.URL.RawQuery = query.Encode()
+
+	response, err := http.DefaultClient.Do(request)
+	defer response.Body.Close()
+
+	if err != nil {
+		fmt.Printf("Failed to send request to holodex: %s", err)
+		return nil, err
+	}
+
+	body, err := ioutil.ReadAll(response.Body)
+
+	if err != nil {
+		fmt.Printf("Failed to read response from holodex: %s", err)
+		return nil, err
+	}
+
+	var results []UpcomingStream
+
+	if err := json.Unmarshal(body, &results); err != nil {
+		fmt.Printf("Failed to unmarshal json response from holodex: %s", err)
+		return nil, err
+	}
+
+	return results, nil
+}

--- a/main.go
+++ b/main.go
@@ -51,6 +51,14 @@ func main() {
 
 	go app.restartRecording()
 
+	if strings.ToLower(os.Getenv("HOLODEX_ENABLE")) == "true" {
+		log.Println("Holodex auto fetching is enabled")
+
+		if _, err := Scheduler.SingletonMode().Every("1h").LimitRunsTo(1).StartImmediately().Do(QueueUpcomingStreams, app); err != nil {
+			sentry.CaptureException(err)
+		}
+	}
+
 	setupServer(address, app)
 }
 

--- a/submit.go
+++ b/submit.go
@@ -3,11 +3,8 @@ package main
 import (
 	"database/sql"
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
-	"os"
-	"pomu/s3"
 	"strings"
 	"time"
 
@@ -128,21 +125,8 @@ func (app *Application) SubmitVideo(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Find a suitable thumbnail
-		thumbnailUrl := ""
-		for _, thumbnail := range []*youtube.Thumbnail{
-			videoMetadata.Snippet.Thumbnails.Maxres,
-			videoMetadata.Snippet.Thumbnails.High,
-			videoMetadata.Snippet.Thumbnails.Medium,
-			videoMetadata.Snippet.Thumbnails.Standard,
-			videoMetadata.Snippet.Thumbnails.Default,
-		} {
-			if thumbnail != nil {
-				thumbnailUrl = thumbnail.Url
-				break
-			}
-		}
-		thumbnailUrl, err = saveThumbnail(videoId, thumbnailUrl)
+		thumbnailUrl, err := SaveThumbnail(videoId, FindSuitableThumbnail(videoMetadata.Snippet.Thumbnails))
+
 		if err != nil {
 			http.Error(w, "Failed to save thumbnail for video "+videoId, http.StatusInternalServerError)
 			return
@@ -294,28 +278,4 @@ func PeekForQualities(w http.ResponseWriter, r *http.Request) {
 	}
 
 	SerializeJson(w, qualities)
-}
-
-// Saves a thumbnail to S3
-func saveThumbnail(id string, url string) (string, error) {
-	s3Client, err := s3.New(os.Getenv("S3_BUCKET"))
-
-	if err != nil {
-		log.Printf("[warn] failed to create s3 client in order to upload thumbnail: %s\n", err)
-		return url, err
-	}
-
-	response, err := http.Get(url)
-
-	if err != nil {
-		log.Printf("[warn] failed to get thumbnail from youtube: %s\n", err)
-		return url, err
-	}
-
-	if err := s3Client.Upload(fmt.Sprintf("%s.jpg", id), response.Body); err != nil {
-		log.Println("s3 thumbnail upload failed:", err)
-		return url, err
-	}
-
-	return fmt.Sprintf("%s/%s.jpg", os.Getenv("S3_DOWNLOAD_URL"), id), nil
 }

--- a/thumbnail.go
+++ b/thumbnail.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"google.golang.org/api/youtube/v3"
+	"log"
+	"net/http"
+	"os"
+	"pomu/s3"
+)
+
+// FindSuitableThumbnail returns the highest resolution thumbnail url which is available
+func FindSuitableThumbnail(details *youtube.ThumbnailDetails) string {
+	qualities := []*youtube.Thumbnail{
+		details.Maxres,
+		details.High,
+		details.Medium,
+		details.Standard,
+		details.Default,
+	}
+
+	for _, thumbnail := range qualities {
+		if thumbnail != nil {
+			return thumbnail.Url
+		}
+	}
+
+	return ""
+}
+
+// SaveThumbnail saves a thumbnail to S3
+func SaveThumbnail(id string, url string) (string, error) {
+	s3Client, err := s3.New(os.Getenv("S3_BUCKET"))
+
+	if err != nil {
+		log.Printf("[warn] failed to create s3 client in order to upload thumbnail: %s\n", err)
+		return url, err
+	}
+
+	response, err := http.Get(url)
+
+	if err != nil {
+		log.Printf("[warn] failed to get thumbnail from youtube: %s\n", err)
+		return url, err
+	}
+
+	if err := s3Client.Upload(fmt.Sprintf("%s.jpg", id), response.Body); err != nil {
+		log.Println("s3 thumbnail upload failed:", err)
+		return url, err
+	}
+
+	return fmt.Sprintf("%s/%s.jpg", os.Getenv("S3_DOWNLOAD_URL"), id), nil
+}

--- a/thumbnail.go
+++ b/thumbnail.go
@@ -44,6 +44,8 @@ func SaveThumbnail(id string, url string) (string, error) {
 		return url, err
 	}
 
+	defer response.Body.Close()
+
 	if err := s3Client.Upload(fmt.Sprintf("%s.jpg", id), response.Body); err != nil {
 		log.Println("s3 thumbnail upload failed:", err)
 		return url, err


### PR DESCRIPTION
this pr adds support to automatically archive live streams according to an user defined criteria, at the earliest 24 hours ahead of scheduled start.

dev.pomu.app will be configured like this:
```
HOLODEX_ENABLE=true
HOLODEX_ORGS="Hololive,Nijisanji,VShojo,VOMS,PRISM"
HOLODEX_TOPIC=singing
```