### PR TITLE
defer db rollbacks upon transaction acquisition

### DIFF
--- a/history.go
+++ b/history.go
@@ -32,6 +32,8 @@ func (app *Application) GetHistory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	defer tx.Rollback()
+
 	whereClause := ""
 
 	if !showUnfinished {

--- a/queue.go
+++ b/queue.go
@@ -17,6 +17,8 @@ func (app *Application) getQueue() (videos []Video, err error) {
 		return
 	}
 
+	defer tx.Rollback()
+
 	rows, err := tx.Query("select * from videos where finished = false order by start")
 
 	if err != nil {

--- a/stats.go
+++ b/stats.go
@@ -16,6 +16,8 @@ func (app *Application) GetStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	defer tx.Rollback()
+
 	videoAmount := 0
 	totalFileSize := 0
 	totalLength := 0

--- a/submit.go
+++ b/submit.go
@@ -104,6 +104,8 @@ func (app *Application) SubmitVideo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	defer tx.Rollback()
+
 	var video Video
 	err = tx.QueryRow("select * from videos where id = $1 limit 1", videoId).Scan(
 		&video.Id,

--- a/users.go
+++ b/users.go
@@ -48,6 +48,8 @@ func GetUser(id string, db *sql.DB) (*User, error) {
 		return nil, err
 	}
 
+	defer tx.Rollback()
+
 	statement, err := tx.Prepare("select * from users where id = $1 limit 1")
 
 	if err != nil {
@@ -81,6 +83,8 @@ func CreateUser(userInfo *googleOauth2.Userinfo, db *sql.DB) (*User, error) {
 		sentry.CaptureException(err)
 		return nil, err
 	}
+
+	defer tx.Rollback()
 
 	statement, err := tx.Prepare("insert into users (id, name, avatar) values ($1, $2, $3) returning *")
 

--- a/video.go
+++ b/video.go
@@ -130,6 +130,8 @@ func recordFinished(db *sql.DB, id string, size int64) error {
 		return err
 	}
 
+	defer tx.Rollback()
+
 	length := videoLengthFromLog(id)
 
 	log.Println("Finishing video", id, "with size", size, "and length", length)
@@ -156,10 +158,15 @@ func recordFailed(db *sql.DB, id string) error {
 	// TODO(emily): Probably want to make sure that s3 is cleaned up as well
 
 	tx, err := db.Begin()
+
 	if err != nil {
 		return err
 	}
+
+	defer tx.Rollback()
+
 	_, err = tx.Exec("delete from videos where id = $1", id)
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fixes #7
ref: https://go.dev/doc/database/execute-transactions#example